### PR TITLE
Update URL to Entur's developer site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # open-data
-Norway is finally united - public transport - wise 😍. On 2017-11-02, our good friends in Entur launched the Norwegian national travel planner, as well as a platform for open public transport data and APIs on  https://entur.org/dev 
+Norway is finally united - public transport - wise 😍. On 2017-11-02, our good friends in Entur launched the Norwegian national travel planner, as well as a platform for open public transport data and APIs on  https://developer.entur.org
 
 ## Licence
 Our open data and APIs are licenced under the Norwegian [Licence for Open Government Data (NLOD)](http://data.norge.no/nlod/en).


### PR DESCRIPTION
https://entur.org/dev just redirects to https://developer.entur.org.